### PR TITLE
typo spinner.js

### DIFF
--- a/src/component/helper/spinner.js
+++ b/src/component/helper/spinner.js
@@ -1,4 +1,4 @@
-'use srtrict';
+'use strict';
 
 const ora = require('ora');
 


### PR DESCRIPTION
there is a typo in 'use strict'